### PR TITLE
feature/gcp_credentials_migration

### DIFF
--- a/ETL_Airflow/dags/tasks/ingestion_task.py
+++ b/ETL_Airflow/dags/tasks/ingestion_task.py
@@ -217,7 +217,7 @@ def m_ingest_data_into_sales():
         spark=create_session()
 
         # Define the GCS bucket name
-        GCS_BUCKET_NAME = "meta-morph"
+        GCS_BUCKET_NAME = "meta-morph-flow"
         today_str = "20250322"
 
         # GCS path to the sales CSV file for today's date

--- a/Rest-API/main.py
+++ b/Rest-API/main.py
@@ -81,7 +81,7 @@ async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(
 
 @app.get("/v1/products")
 def get_products():
-    blob = get_latest_file_from_gcs("product")
+    blob = get_latest_file_from_gcs("product_new")
     df = read_csv_from_gcs(blob)
     return {"status": 200, "data": df.to_dict(orient="records")}
 

--- a/Rest-API/main.py
+++ b/Rest-API/main.py
@@ -27,7 +27,7 @@ class Token(BaseModel):
     token_type: str
 
 # GCS Configuration
-GCS_BUCKET_NAME = "meta-morph"
+GCS_BUCKET_NAME = "meta-morph-flow"
 GCS_CREDENTIALS_PATH = env["GCS_CREDENTIALS_PATH"]
 
 def get_gcs_client():
@@ -81,7 +81,7 @@ async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(
 
 @app.get("/v1/products")
 def get_products():
-    blob = get_latest_file_from_gcs("product_new")
+    blob = get_latest_file_from_gcs("product")
     df = read_csv_from_gcs(blob)
     return {"status": 200, "data": df.to_dict(orient="records")}
 


### PR DESCRIPTION
As per the Story[ MM - 90 :](https://trello.com/c/WNVw7t2g/90-asritha-migration-to-new-gcp-account-update-secrets-and-bucket-reference)

- Replace the old GCP credentials in all Airflow tasks and Rest APIs
- The bucket name has changed from meta-morph ➜ meta-morph-flow.
- Data workflows continue functioning with the new credentials and bucket.

![Screenshot (41)](https://github.com/user-attachments/assets/8429a174-470e-4b13-be55-febfdc44cd05)
